### PR TITLE
Улучшена работа с UTF-8, а также "замаскирован" баг в get_class_index()

### DIFF
--- a/classifier.py
+++ b/classifier.py
@@ -1,3 +1,4 @@
+import codecs
 import numpy as np
 
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
@@ -22,7 +23,7 @@ def train_and_test():
 
     text_data, attrs_data = [], []
 
-    failsFile = open(RESULTS_PATH + 'fails.txt', 'w')
+    failsFile = codecs.open(RESULTS_PATH + 'fails.txt', mode='w', encoding='utf-8', errors='ignore')
     for site in sites:
         try:
             text, attrs = load_file(site[0])
@@ -32,8 +33,12 @@ def train_and_test():
         text_data.append(text)
         attrs_data.append(attrs)
 
-    write_to_file(RESULTS_PATH, 'text_data.txt', json.dumps(text_data))
-    write_to_file(RESULTS_PATH, 'attrs_data.txt', json.dumps(attrs_data))
+    """with codecs.open(os.path.join(os.path.normpath(RESULTS_PATH), 'text_data.txt'), mode='w', encoding='utf-8') as fp:
+        json.dump(text_data, fp, ensure_ascii=False, indent=4)
+    with codecs.open(os.path.join(os.path.normpath(RESULTS_PATH), 'attrs_data.txt'), mode='w', encoding='utf-8') as fp:
+        json.dump(attrs_data, fp, ensure_ascii=False, indent=4)"""
+    write_to_file(RESULTS_PATH, 'text_data.txt', json.dumps(text_data, ensure_ascii=False, indent=4))
+    write_to_file(RESULTS_PATH, 'attrs_data.txt', json.dumps(attrs_data, ensure_ascii=False, indent=4))
 
     a = text_vectorizer.fit_transform(text_data)
     b = attrs_vectorizer.fit_transform(attrs_data)
@@ -64,7 +69,7 @@ def train_and_test():
     #     i += 1
 
     # make predictions
-    f = open('results.txt', 'w')
+    f = codecs.open('results.txt', mode='w', encoding='utf-8', errors='ignore')
     print('Results of training:', file=f)
     for i in range(len(CLASSES_LIST)):
         expected = y[i]

--- a/preparations.py
+++ b/preparations.py
@@ -1,3 +1,4 @@
+import codecs
 import json
 
 from random import shuffle
@@ -15,7 +16,7 @@ def sign(x):
 
 def get_site_classes(classes):
     sites_with_classes = dict()
-    with open('classes_list.txt', 'w') as thefile:
+    with codecs.open('classes_list.txt', mode='w', encoding='utf-8', errors='ignore') as thefile:
         for key, val in classes.items():
             for site in val:
                 if site.startswith('www.'):
@@ -27,14 +28,12 @@ def get_site_classes(classes):
 
 WEBPAGES_PATH = 'webpages/'
 RESULTS_PATH = 'results/'
-if not os.path.isdir(RESULTS_PATH):
+if not os.path.isdir(os.path.normpath(RESULTS_PATH)):
     os.mkdir(RESULTS_PATH)
 VECTORIZER_DATA_FILE = ['text_vect_data.txt', 'attrs_vect_data.txt']
 PAGE_CLASSES_FILE = './metadata.json'
-PAGE_CLASSES = dict()
-CLASSES_LIST = []
 
-with open(PAGE_CLASSES_FILE) as data:
+with codecs.open(os.path.normpath(PAGE_CLASSES_FILE), mode='r', encoding='utf-8', errors='ignore') as data:
     PAGE_CLASSES = json.load(data)
     CLASSES_LIST = list(PAGE_CLASSES.keys())
 
@@ -45,7 +44,7 @@ SITES_WITH_CLASSES = get_site_classes(PAGE_CLASSES)
 def load_sites(path):
     sites_list = []
 
-    for dirname in os.listdir(path):
+    for dirname in os.listdir(os.path.normpath(path)):
         dir = os.path.join(path, dirname)
         for file in os.listdir(dir):
             file_path = os.path.join(dir, file)
@@ -58,20 +57,30 @@ def load_sites(path):
 
 
 def get_class_index(site_name):
-    return CLASSES_LIST.index(SITES_WITH_CLASSES[site_name])
+    try:
+        class_index = CLASSES_LIST.index(SITES_WITH_CLASSES[site_name])
+    except:
+        class_index = -1
+    return class_index
 
 
 def load_file(file):
     # print(file)
-
-    tree = ET.parse(file, parser=HTMLParser())
-    if tree.getroot() is None:
+    with codecs.open(file, mode='r', encoding='utf-8', errors='ignore') as f:
+        html_string = f.read()
+    root = ET.fromstring(html_string, parser=HTMLParser())
+    if root is None:
         raise Exception('Can\'t get root.')
+    """tree = ET.parse(os.path.normpath(file), parser=HTMLParser())
+    if tree.getroot() is None:
+        raise Exception('Can\'t get root.')"""
 
-    title = tree.getroot().find('title')
+    #title = tree.getroot().find('title')
+    title = root.find('title')
     if title is None:
         title = ''
-    body = tree.getroot().find('body')
+    #body = tree.getroot().find('body')
+    body = root.find('body')
     if body is None:
         raise Exception('Can\'t find the BODY tag.')
 
@@ -99,22 +108,29 @@ def corpus_transformation(sites, text_vectorizer, attrs_vectorizer):
     X = None
     fails = ''
     for site in sites:
+        class_index = get_class_index(site[1])
+        if class_index < 0:
+            continue
+        text = None
         try:
             text, attrs = load_file(site[0])
         except Exception as exception:
             fails += '{0}: {1}\n'.format(site[1], exception)
+        if text is None:
+            continue
         if not isinstance(text, str):
             print('text is', type(text))
-        y.append(get_class_index(site[1]))
-        X_row = hstack([
-            text_vectorizer.transform([text]),
-            # Uncomment this string to add attributes data into learning data
-            # attrs_vectorizer.transform([attrs])
-        ])
-        if X is None:
-            X = X_row
         else:
-            X = vstack((X, X_row))
+            y.append(get_class_index(site[1]))
+            X_row = hstack([
+                text_vectorizer.transform([text]),
+                # Uncomment this string to add attributes data into learning data
+                # attrs_vectorizer.transform([attrs])
+            ])
+            if X is None:
+                X = X_row
+            else:
+                X = vstack((X, X_row))
     # print(type(y))
     # print(len(y))
     # print(X.shape)

--- a/utils.py
+++ b/utils.py
@@ -1,10 +1,11 @@
+import codecs
 import os
 
 
 def write_to_file(dir, filename, data):
     if not os.path.exists(dir):
         os.makedirs(dir)
-    with open(dir + filename, 'w') as file:
+    with codecs.open(dir + filename, mode='w', encoding='utf-8', errors='ignore') as file:
         file.write(data)
 
 
@@ -17,7 +18,10 @@ def shuffle_set(set, mix):
 
 class LogFile:
     def __init__(self, file):
-        self.file = open(file, 'rw')
+        self.file = codecs.open(file, mode='rw', encoding='utf-8', errors='ignore')
+
+    def __del__(self):
+        self.file.close()
 
     def write(self, site, exception):
         self.file.write()


### PR DESCRIPTION
1. Для сохранения/загрузки текста в формате UTF-8 лучше всего использовать не обычные файловые дескрипторы, получаемые стандартной функцией open(), а специальные дескрипторы текстовых UTF-8-файлов, получаемые через codecs.open() (предварительно нужно импортировать модуль codecs).

2. У меня всё время возникала ошибка 

File "e:\SiteClassificator\preparations.py", line 60, in get_class_index
    class_name = SITES_WITH_CLASSES[site_name]
KeyError: 'sch1034.mskobr.ru'

Я не разбирался глубоко в причинах её возникновения (думаю, что это стоит сделать вам, Виктор), но убрал её с глаз путём обёртки строки, в которой возбуждалось исключение, обёрткой try...except. Теперь исключение в функции get_class_index() не приводит к падению программы, а приводит к возвращению -1 из этой функции. Это изменение поддержано в функции corpus_transformation(), где, собственно, и применяется функция get_class_index(). Теперь, если в функции get_class_index() что-то пошло не так и вернулось -1, соответствующий сайт не участвует в формировании обучающего/тестового множеств.

Но это лишь маскировка ошибки, на мой взгляд. По-настоящему исправить ошибку - это значит разобраться в причинах её возникновения, и это дело я поручаю Вам :-)